### PR TITLE
Add text encoder for non-ASCII characters

### DIFF
--- a/encoding/text.go
+++ b/encoding/text.go
@@ -1,0 +1,34 @@
+package encoding
+
+import (
+	"fmt"
+)
+
+var (
+	_ Encoder = (*textEncoder)(nil)
+
+	// Text is based on ASCII encoder without the validation to generate an
+	// error when there are non-ASCII characters. It returns the field content
+	// as it is. This encoder is used for decoding of fields with content in
+	// other idioms than english, like chinese, japanese, etc.
+	Text = &textEncoder{}
+)
+
+type textEncoder struct{}
+
+func (e textEncoder) Encode(data []byte) ([]byte, error) {
+	return data, nil
+}
+
+func (e textEncoder) Decode(data []byte, length int) ([]byte, int, error) {
+	// length should be positive
+	if length < 0 {
+		return nil, 0, fmt.Errorf("invalid length: %d", length)
+	}
+
+	if len(data) < length {
+		return nil, 0, fmt.Errorf("not enough data to decode. expected len %d, got %d", length, len(data))
+	}
+
+	return data[:length], length, nil
+}

--- a/encoding/text_test.go
+++ b/encoding/text_test.go
@@ -1,0 +1,49 @@
+package encoding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestText(t *testing.T) {
+	enc := &textEncoder{}
+
+	t.Run("Decode", func(t *testing.T) {
+		res, read, err := enc.Decode([]byte("hello"), 5)
+
+		require.NoError(t, err)
+		require.Equal(t, []byte("hello"), res)
+		require.Equal(t, 5, read)
+
+		res, read, err = enc.Decode([]byte("hello, 世界!"), 14)
+
+		require.NoError(t, err)
+		require.Equal(t, []byte("hello, 世界!"), res)
+		require.Equal(t, 14, read)
+
+		_, _, err = enc.Decode([]byte("hello"), 6)
+		require.Error(t, err)
+		require.EqualError(t, err, "not enough data to decode. expected len 6, got 5")
+
+		_, _, err = enc.Decode(nil, 6)
+		require.Error(t, err)
+		require.EqualError(t, err, "not enough data to decode. expected len 6, got 0")
+
+		_, _, err = enc.Decode(nil, -1)
+		require.Error(t, err)
+		require.EqualError(t, err, "invalid length: -1")
+	})
+
+	t.Run("Encode", func(t *testing.T) {
+		res, err := enc.Encode([]byte("hello"))
+
+		require.NoError(t, err)
+		require.Equal(t, []byte("hello"), res)
+
+		res, err = enc.Encode([]byte("hello, 世界!"))
+
+		require.NoError(t, err)
+		require.Equal(t, []byte("hello, 世界!"), res)
+	})
+}


### PR DESCRIPTION
Added new encoder for decoding of fields that have content in other idioms than english, like chinese, japanese, etc., with non-ASCII characters.