### PR TITLE
Add prefix for fields with a delimiter

### DIFF
--- a/prefix/delimiter.go
+++ b/prefix/delimiter.go
@@ -1,0 +1,59 @@
+package prefix
+
+import "fmt"
+
+// delimiterPrefixer implements Prefixer interface to allow looking for a
+// delimiter in the content of a field which determines its end and therefore
+// its length.
+type delimiterPrefixer struct {
+	delimiterChar byte
+	encoder       string
+}
+
+// NewDelimiter creates a Prefixer which can searches for the given char byte
+// in a field content to determine its end and therefore its length. Name is
+// also required to complete the identity of the prefixer using the Inspect
+// method.
+// This Prefixer is not initialized like the others because the delimiter char
+// must be provided to know what to look for.
+// NOTE: The delimiter char is included in the length of the field.
+//
+// Example:
+//
+//	backslashPrefixer := NewDelimiter('\x5C', "ASCIIBackslash")
+func NewDelimiter(char byte, name string) Prefixer {
+	return &delimiterPrefixer{delimiterChar: char, encoder: name}
+}
+
+func (b *delimiterPrefixer) EncodeLength(maxLen, dataLen int) ([]byte, error) {
+	if dataLen > maxLen {
+		return nil, fmt.Errorf("field length: %d is larger than maximum: %d", dataLen, maxLen)
+	}
+
+	return []byte{}, nil
+}
+
+// DecodeLength iterates the content of a field by byte until the delimiter is
+// reached, and returns the number of iterations required to find it. If the
+// delimiter is not in the maximum length specified for the field, an error is
+// returned.
+func (b *delimiterPrefixer) DecodeLength(maxLen int, data []byte) (int, int, error) {
+	var dataLen int
+	for _, char := range data {
+		dataLen++
+
+		if dataLen > maxLen {
+			return 0, 0, fmt.Errorf("delimiter not found in first %d bytes", maxLen)
+		}
+
+		if char == b.delimiterChar {
+			return dataLen, 0, nil
+		}
+	}
+
+	return 0, 0, fmt.Errorf("delimiter not found")
+}
+
+func (b *delimiterPrefixer) Inspect() string {
+	return fmt.Sprintf("%sDelimiter", b.encoder)
+}

--- a/prefix/delimiter_test.go
+++ b/prefix/delimiter_test.go
@@ -1,0 +1,97 @@
+package prefix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_BackslashPrefix_EncodeLength(t *testing.T) {
+	testCases := []struct {
+		name    string
+		maxLen  int
+		dataLen int
+		wantErr string
+	}{
+		{
+			name:    "Success",
+			maxLen:  2,
+			dataLen: 2,
+		},
+		{
+			name:    "Error_When_MaxLenAchieved",
+			maxLen:  2,
+			dataLen: 3,
+			wantErr: "field length: 3 is larger than maximum: 2",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := NewDelimiter('\x5C', "ASCIIBackslash")
+
+			data, err := b.EncodeLength(tc.maxLen, tc.dataLen)
+			if err != nil || tc.wantErr != "" {
+				assert.EqualError(t, err, tc.wantErr)
+				return
+			}
+
+			assert.Equal(t, []byte{}, data)
+		})
+	}
+}
+
+func Test_BackslashPrefix_DecodeLength(t *testing.T) {
+	testCases := []struct {
+		name    string
+		maxLen  int
+		data    []byte
+		wantLen int
+		wantErr string
+	}{
+		{
+			name:    "Success_When_CharInLastByte",
+			maxLen:  5,
+			data:    []byte("Data\\"),
+			wantLen: 5,
+		},
+		{
+			name:    "Success_When_CharInTheMiddleOfData",
+			maxLen:  10,
+			data:    []byte("Data\\remaining"),
+			wantLen: 5,
+		},
+		{
+			name:    "NoCharFound_When_MaxLenAchieved",
+			maxLen:  5,
+			data:    []byte("More data\\"),
+			wantErr: "delimiter not found in first 5 bytes",
+		},
+		{
+			name:    "NoCharFound_When_TotalDataIterated",
+			maxLen:  10,
+			data:    []byte("Total data"),
+			wantErr: "delimiter not found",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := NewDelimiter('\x5C', "ASCIIBackslash")
+
+			length, _, err := b.DecodeLength(tc.maxLen, tc.data)
+			if err != nil || tc.wantErr != "" {
+				assert.EqualError(t, err, tc.wantErr)
+				return
+			}
+
+			assert.Equal(t, tc.wantLen, length)
+		})
+	}
+}
+
+func Test_BackslashPrefix_Inspect(t *testing.T) {
+	b := NewDelimiter('\x5C', "ASCIIBackslash")
+
+	inspection := b.Inspect()
+
+	assert.Equal(t, "ASCIIBackslashDelimiter", inspection)
+}


### PR DESCRIPTION
Added a prefix that looks for a delimiter in the content of a field to determine its end and therefore its length.