### PR TITLE
Add composite for fields with occurrences

### DIFF
--- a/field/multiple_occurrences.go
+++ b/field/multiple_occurrences.go
@@ -1,0 +1,429 @@
+package field
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/moov-io/iso8583/utils"
+)
+
+// MultipleOccurrences implements Field interface to hold ISO8583 subfields that can appear
+// multiple times in the same field, calling each of these appearances an occurrence.
+// This is a particular logic of iso format to store different kind of values, which have a certain
+// relationship, in the same point.
+// For example, Currency Exponents Field, which identifies the implicit decimal point locations associated with each
+// ISO standard currency code used in a message, has one occurrence for each of those distinct currency codes.
+type MultipleOccurrences struct {
+	spec *Spec
+
+	orderedSpecFieldTags []string
+
+	// stores all fields corresponding to their occurrence according to the spec.
+	subfields []map[string]Field
+
+	// tracks which subfields were set for each of the occurrences.
+	setSubfields []map[string]struct{}
+}
+
+// NewMultipleOccurrencesField creates a new instance of the *MultipleOccurrences struct,
+// validates and sets its Spec before returning it.
+// Refer to SetSpec() for more information on Spec validation.
+func NewMultipleOccurrencesField(spec *Spec) *MultipleOccurrences {
+	f := &MultipleOccurrences{}
+	f.SetSpec(spec)
+	f.ConstructSubfields()
+
+	return f
+}
+
+// ConstructSubfields initializes the list of fields where the decoded data will be stored. This method should be called
+// before any Unpack process is executed to avoid data inconsistency due to the preexisting information.
+func (c *MultipleOccurrences) ConstructSubfields() {
+	c.subfields = []map[string]Field{CreateSubfields(c.spec)}
+	c.setSubfields = []map[string]struct{}{make(map[string]struct{})}
+}
+
+// Spec returns the spec that was set at the initialization of MultipleOccurrences.
+func (c *MultipleOccurrences) Spec() *Spec {
+	return c.spec
+}
+
+// getSubfields returns the map of subfields that were set for a given occurrence index.
+func (c *MultipleOccurrences) getSubfields(occurrenceIndex int) map[string]Field {
+	fields := map[string]Field{}
+	for i := range c.setSubfields[occurrenceIndex] {
+		fields[i] = c.subfields[occurrenceIndex][i]
+	}
+	return fields
+}
+
+// SetSpec validates the spec and creates new instances of Subfields defined
+// in the specification.
+// NOTE: MultipleOccurrences does not support padding on the base spec. Therefore, users
+// should only pass None or nil values for ths type. Passing any other value
+// will result in a panic.
+func (c *MultipleOccurrences) SetSpec(spec *Spec) {
+	if err := validateCompositeSpec(spec); err != nil {
+		panic(err)
+	}
+	c.spec = spec
+	c.orderedSpecFieldTags = orderedKeys(spec.Subfields, spec.Tag.Sort)
+}
+
+// SetData Deprecated. Use Marshal instead
+func (c *MultipleOccurrences) SetData(v interface{}) error {
+	return c.Marshal(v)
+}
+
+// Unmarshal traverses through the stored subfields occurrences, matches them with their field in the provided data
+// parameter, and calls Unmarshal(...) to set the data in the result.
+//
+// A valid input is as follows:
+//
+//	type CompositeData struct {
+//	    F1 *String
+//	    F2 *String
+//	    F3 *Numeric
+//	    F4 *SubfieldCompositeData
+//	}
+//	var input []CompositeData
+func (c *MultipleOccurrences) Unmarshal(v interface{}) error {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return errors.New("data is not a pointer or nil")
+	}
+
+	// get the slice from the pointer
+	dataSlice := rv.Elem()
+	if dataSlice.Kind() != reflect.Slice {
+		return errors.New("data is not a slice")
+	}
+
+	for occurrenceIndex := range c.setSubfields {
+		if dataSlice.Len()-1 < occurrenceIndex {
+			dataSlice.Set(reflect.Append(dataSlice, reflect.New(dataSlice.Type().Elem()).Elem()))
+		}
+
+		// get the struct from the pointer
+		dataStruct := dataSlice.Index(occurrenceIndex)
+		if dataStruct.Kind() != reflect.Struct {
+			return errors.New("element data is not a struct")
+		}
+
+		// iterate over struct fields
+		for i := 0; i < dataStruct.NumField(); i++ {
+			indexOrTag, _ := getFieldIndexOrTag(dataStruct.Type().Field(i))
+
+			// skip field without index
+			if indexOrTag == "" {
+				continue
+			}
+
+			messageField, ok := c.subfields[occurrenceIndex][indexOrTag]
+			if !ok {
+				continue
+			}
+
+			// unmarshal only subfield that has the value set
+			if _, set := c.setSubfields[occurrenceIndex][indexOrTag]; !set {
+				continue
+			}
+
+			dataField := dataStruct.Field(i)
+			if dataField.IsNil() {
+				dataField.Set(reflect.New(dataField.Type().Elem()))
+			}
+
+			if err := messageField.Unmarshal(dataField.Interface()); err != nil {
+				return fmt.Errorf("failed to get data from field %s: %w", indexOrTag, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Marshal traverses through fields provided in the data parameter, matches them
+// with their spec definition, and calls Marshal(...) on each spec field with the
+// appropriate data
+//
+// A valid input is as follows:
+//
+//	type CompositeData struct {
+//	    F1 *String
+//	    F2 *String
+//	    F3 *Numeric
+//	    F4 *SubfieldCompositeData
+//	}
+//	input := []CompositeData{filled data}
+func (c *MultipleOccurrences) Marshal(v interface{}) error {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return errors.New("data is not a pointer or nil")
+	}
+
+	// get the struct from the pointer
+	dataSlice := rv.Elem()
+	if dataSlice.Kind() != reflect.Slice {
+		return errors.New("data is not a slice")
+	}
+
+	for occurrenceIndex := 0; occurrenceIndex < dataSlice.Len(); occurrenceIndex++ {
+		// get the struct from the pointer
+		dataStruct := dataSlice.Index(occurrenceIndex)
+		if dataStruct.Kind() != reflect.Struct {
+			return errors.New("element data is not a struct")
+		}
+
+		if len(c.subfields)-1 < occurrenceIndex {
+			c.addNewOccurrence()
+		}
+
+		// iterate over struct fields
+		for i := 0; i < dataStruct.NumField(); i++ {
+			indexOrTag, _ := getFieldIndexOrTag(dataStruct.Type().Field(i))
+
+			// skip field without index
+			if indexOrTag == "" {
+				continue
+			}
+
+			messageField, ok := c.subfields[occurrenceIndex][indexOrTag]
+			if !ok {
+				continue
+			}
+
+			dataField := dataStruct.Field(i)
+			if dataField.IsNil() {
+				continue
+			}
+
+			if err := messageField.Marshal(dataField.Interface()); err != nil {
+				return fmt.Errorf("failed to set data from field %s: %w", indexOrTag, err)
+			}
+
+			c.setSubfields[occurrenceIndex][indexOrTag] = struct{}{}
+		}
+	}
+
+	return nil
+}
+
+// Pack deserializes data held by the receiver (via SetData) into bytes and returns an error on failure.
+func (c *MultipleOccurrences) Pack() ([]byte, error) {
+	packed, err := c.pack()
+	if err != nil {
+		return nil, err
+	}
+
+	packedLength, err := c.spec.Pref.EncodeLength(c.spec.Length, len(packed))
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode length: %w", err)
+	}
+
+	return append(packedLength, packed...), nil
+}
+
+// Unpack takes in a byte array and serializes them into the receiver's
+// subfields. An offset (unit depends on encoding and prefix values) is
+// returned on success. A non-nil error is returned on failure.
+func (c *MultipleOccurrences) Unpack(data []byte) (int, error) {
+	dataLen, offset, err := c.spec.Pref.DecodeLength(c.spec.Length, data)
+	if err != nil {
+		return 0, fmt.Errorf("failed to decode length: %w", err)
+	}
+
+	isVariableLength := false
+	if offset != 0 {
+		isVariableLength = true
+	}
+
+	if offset+dataLen > len(data) {
+		return 0, fmt.Errorf("not enough data to unpack, expected: %d, got: %d", offset+dataLen, len(data))
+	}
+	// data is stripped of the prefix before it is provided to unpack().
+	// Therefore, it is unaware of when to stop parsing unless we bound the
+	// length of the slice by the data length.
+	read, err := c.unpack(data[offset:offset+dataLen], isVariableLength)
+	if err != nil {
+		return 0, err
+	}
+	if dataLen != read {
+		return 0, fmt.Errorf("data length: %v does not match aggregate data read from decoded subfields: %v", dataLen, read)
+	}
+
+	return offset + read, nil
+}
+
+// SetBytes iterates over the receiver's subfields and unpacks them.
+// Data passed into this method must consist of the necessary information to
+// pack all subfields in full. However, unlike Unpack(), it requires the
+// aggregate length of the subfields not to be encoded in the prefix.
+func (c *MultipleOccurrences) SetBytes(data []byte) error {
+	_, err := c.unpack(data, false)
+	return err
+}
+
+// Bytes iterates over the receiver's subfields and packs them. The result
+// does not incorporate the encoded aggregate length of the subfields in the
+// prefix.
+func (c *MultipleOccurrences) Bytes() ([]byte, error) {
+	return c.pack()
+}
+
+// String iterates over the receiver's subfields, packs them and converts the
+// result to a string. The result does not incorporate the encoded aggregate
+// length of the subfields in the prefix.
+func (c *MultipleOccurrences) String() (string, error) {
+	b, err := c.Bytes()
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// MarshalJSON implements the encoding/json.Marshaler interface and return the json array with the stored subfields for
+// the multiple occurrences.
+//
+// A json result for a field with multiple occurrences looks like:
+//
+// [{"subfield1":"valueOccurrence1","subfield2":"valueOccurrence1"},
+// {"subfield1":"valueOccurrence2","subfield2":"valueOccurrence2"}]
+func (c *MultipleOccurrences) MarshalJSON() ([]byte, error) {
+	buf := &bytes.Buffer{}
+	buf.Write([]byte{'['})
+	for occurrenceIndex := range c.setSubfields {
+		subfieldsData := OrderedMap(c.getSubfields(occurrenceIndex))
+
+		subfieldsJsonData, err := json.Marshal(subfieldsData)
+		if err != nil {
+			return nil, utils.NewSafeError(err, "failed to JSON marshal map to bytes")
+		}
+
+		buf.Write(subfieldsJsonData)
+
+		if occurrenceIndex != len(c.setSubfields)-1 {
+			buf.Write([]byte{','})
+		}
+	}
+	buf.Write([]byte{']'})
+	return buf.Bytes(), nil
+}
+
+// UnmarshalJSON implements the encoding/json.Unmarshaler interface.
+// An error is thrown if the JSON consists of a subfield that has not
+// been defined in the spec.
+func (c *MultipleOccurrences) UnmarshalJSON(b []byte) error {
+	var data []map[string]json.RawMessage
+	err := json.Unmarshal(b, &data)
+	if err != nil {
+		return utils.NewSafeError(err, "failed to JSON unmarshal bytes to map list")
+	}
+
+	c.ConstructSubfields()
+
+	for occurrenceIndex, occurrenceMap := range data {
+		if len(c.subfields)-1 < occurrenceIndex {
+			c.addNewOccurrence()
+		}
+
+		for tag, rawMsg := range occurrenceMap {
+			if _, ok := c.spec.Subfields[tag]; !ok {
+				return fmt.Errorf("failed to unmarshal subfield %v: received subfield not defined in spec", tag)
+			}
+
+			subfield, ok := c.subfields[occurrenceIndex][tag]
+			if !ok {
+				continue
+			}
+
+			if err := json.Unmarshal(rawMsg, subfield); err != nil {
+				return utils.NewSafeErrorf(err, "failed to unmarshal subfield %v", tag)
+			}
+
+			c.setSubfields[occurrenceIndex][tag] = struct{}{}
+		}
+	}
+
+	return nil
+}
+
+func (c *MultipleOccurrences) pack() ([]byte, error) {
+	if c.spec.Tag != nil && c.spec.Tag.Enc != nil {
+		return nil, fmt.Errorf("unsupported packing of TLV subfields")
+	}
+	var packed []byte
+	for occurrenceIndex := range c.setSubfields {
+		for _, tag := range c.orderedSpecFieldTags {
+			f, ok := c.subfields[occurrenceIndex][tag]
+			if !ok {
+				return nil, fmt.Errorf("no subfield for tag %s", tag)
+			}
+
+			if _, set := c.setSubfields[occurrenceIndex][tag]; !set {
+				continue
+			}
+
+			packedBytes, err := f.Pack()
+			if err != nil {
+				return nil, fmt.Errorf("failed to pack subfield %v: %w", tag, err)
+			}
+			packed = append(packed, packedBytes...)
+		}
+	}
+
+	return packed, nil
+}
+
+func (c *MultipleOccurrences) unpack(data []byte, isVariableLength bool) (int, error) {
+	if c.spec.Tag.Enc != nil {
+		return 0, fmt.Errorf("unsupported unpacking of TLV subfields")
+	}
+	return c.unpackSubfields(data, isVariableLength)
+}
+
+func (c *MultipleOccurrences) unpackSubfields(data []byte, isVariableLength bool) (int, error) {
+	c.ConstructSubfields()
+	offset := 0
+	occurrenceIndex := 0
+
+	for offset < len(data) {
+		for _, tag := range c.orderedSpecFieldTags {
+			f, ok := c.subfields[occurrenceIndex][tag]
+			if !ok {
+				continue
+			}
+
+			read, err := f.Unpack(data[offset:])
+			if err != nil {
+				return 0, fmt.Errorf("failed to unpack subfield %v: %w", tag, err)
+			}
+
+			c.setSubfields[occurrenceIndex][tag] = struct{}{}
+
+			offset += read
+
+			if isVariableLength && offset >= len(data) {
+				return offset, nil
+			}
+		}
+
+		if offset >= len(data) {
+			break
+		}
+
+		c.addNewOccurrence()
+		occurrenceIndex++
+	}
+
+	return offset, nil
+}
+
+// appends a new item in the subfields list representing a new occurrence.
+func (c *MultipleOccurrences) addNewOccurrence() {
+	c.subfields = append(c.subfields, CreateSubfields(c.spec))
+	c.setSubfields = append(c.setSubfields, make(map[string]struct{}))
+}

--- a/field/multiple_occurrences_test.go
+++ b/field/multiple_occurrences_test.go
@@ -1,0 +1,824 @@
+package field
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/moov-io/iso8583/encoding"
+	"github.com/moov-io/iso8583/padding"
+	"github.com/moov-io/iso8583/prefix"
+	"github.com/moov-io/iso8583/sort"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	multipleOccurrencesFixedLenTestSpec = &Spec{
+		Length:      12,
+		Description: "Test Spec",
+		Pref:        prefix.ASCII.Fixed,
+		Pad:         padding.None,
+		Tag: &TagSpec{
+			Sort: sort.StringsByInt,
+		},
+		Subfields: map[string]Field{
+			"1": NewString(&Spec{
+				Length:      2,
+				Description: "String Field",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.Fixed,
+			}),
+			"2": NewString(&Spec{
+				Length:      2,
+				Description: "String Field",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.Fixed,
+			}),
+			"3": NewNumeric(&Spec{
+				Length:      2,
+				Description: "Numeric Field",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.Fixed,
+			}),
+		},
+	}
+
+	multipleOccurrencesVariableLenTestSpec = &Spec{
+		Length:      36,
+		Description: "Test Spec",
+		Pref:        prefix.ASCII.LL,
+		Tag: &TagSpec{
+			Sort: sort.StringsByInt,
+		},
+		Subfields: map[string]Field{
+			"1": NewString(&Spec{
+				Length:      2,
+				Description: "String Field",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.LL,
+			}),
+			"2": NewString(&Spec{
+				Length:      2,
+				Description: "String Field",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.LL,
+			}),
+			"3": NewNumeric(&Spec{
+				Length:      2,
+				Description: "Numeric Field",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.LL,
+			}),
+			"11": NewComposite(&Spec{
+				Length:      6,
+				Description: "Sub-Composite Field",
+				Pref:        prefix.ASCII.LL,
+				Tag: &TagSpec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pad:    padding.Left('0'),
+					Sort:   sort.StringsByInt,
+				},
+				Subfields: map[string]Field{
+					"1": NewString(&Spec{
+						Length:      2,
+						Description: "String Field",
+						Enc:         encoding.ASCII,
+						Pref:        prefix.ASCII.LL,
+					}),
+				},
+			}),
+		},
+	}
+)
+
+type MultipleOccurrencesTestData struct {
+	F1  *String
+	F2  *String
+	F3  *Numeric
+	F11 *SubMultipleOccurrencesData
+}
+
+type SubMultipleOccurrencesData struct {
+	F1 *String
+}
+
+func TestMultipleOccurrences_SetData(t *testing.T) {
+	t.Run("SetData returns an error on provision of primitive data type", func(t *testing.T) {
+		composite := NewMultipleOccurrencesField(multipleOccurrencesFixedLenTestSpec)
+		err := composite.SetData("primitive str")
+		require.EqualError(t, err, "data is not a pointer or nil")
+	})
+
+	t.Run("SetData returns an error on provision of non slice data type", func(t *testing.T) {
+		composite := NewMultipleOccurrencesField(multipleOccurrencesFixedLenTestSpec)
+		err := composite.SetData(&struct{ Field string }{})
+		require.EqualError(t, err, "data is not a slice")
+	})
+
+	t.Run("SetData returns an error on provision of slice with non struct element data type", func(t *testing.T) {
+		composite := NewMultipleOccurrencesField(multipleOccurrencesFixedLenTestSpec)
+		err := composite.SetData(&[]string{"10"})
+		require.EqualError(t, err, "element data is not a struct")
+	})
+}
+
+func TestMultipleOccurrences_FieldUnmarshal(t *testing.T) {
+	t.Run("Unmarshal returns an error on provision of primitive data type", func(t *testing.T) {
+		composite := NewMultipleOccurrencesField(multipleOccurrencesFixedLenTestSpec)
+		err := composite.Unmarshal("primitive str")
+		require.EqualError(t, err, "data is not a pointer or nil")
+	})
+
+	t.Run("Unmarshal returns an error on provision of non slice data type", func(t *testing.T) {
+		composite := NewMultipleOccurrencesField(multipleOccurrencesFixedLenTestSpec)
+		err := composite.Unmarshal(&struct{ Field string }{})
+		require.EqualError(t, err, "data is not a slice")
+	})
+
+	t.Run("Unmarshal returns an error on provision of slice with non struct element data type", func(t *testing.T) {
+		composite := NewMultipleOccurrencesField(multipleOccurrencesFixedLenTestSpec)
+		err := composite.Unmarshal(&[]string{"10"})
+		require.EqualError(t, err, "element data is not a struct")
+	})
+
+	t.Run("Unmarshal gets data for multiple occurrences field", func(t *testing.T) {
+		// first, we need to populate fields of composite field
+		// we will do it by packing the field
+		composite := NewMultipleOccurrencesField(multipleOccurrencesFixedLenTestSpec)
+		err := composite.SetData(&[]MultipleOccurrencesTestData{
+			{
+				F1: NewStringValue("AB"),
+				F2: NewStringValue("CD"),
+				F3: NewNumericValue(12),
+			},
+			{
+				F1: NewStringValue("EF"),
+				F2: NewStringValue("GH"),
+				F3: NewNumericValue(14),
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = composite.Pack()
+		require.NoError(t, err)
+
+		var data []MultipleOccurrencesTestData
+		require.NoError(t, composite.Unmarshal(&data))
+
+		require.Equal(t, "AB", data[0].F1.Value())
+		require.Equal(t, "CD", data[0].F2.Value())
+		require.Equal(t, 12, data[0].F3.Value())
+		require.Equal(t, "EF", data[1].F1.Value())
+		require.Equal(t, "GH", data[1].F2.Value())
+		require.Equal(t, 14, data[1].F3.Value())
+	})
+
+	t.Run("Unmarshal gets data for multiple occurrences with sub field", func(t *testing.T) {
+		composite := NewMultipleOccurrencesField(multipleOccurrencesVariableLenTestSpec)
+		err := composite.SetData(&[]MultipleOccurrencesTestData{
+			{
+				F1: NewStringValue("7F"),
+				F2: NewStringValue("2F"),
+				F11: &SubMultipleOccurrencesData{
+					F1: NewStringValue("4F"),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = composite.Pack()
+		require.NoError(t, err)
+
+		var data []MultipleOccurrencesTestData
+		require.NoError(t, composite.Unmarshal(&data))
+
+		require.Equal(t, "7F", data[0].F1.Value())
+		require.Equal(t, "2F", data[0].F2.Value())
+		require.Equal(t, "4F", data[0].F11.F1.Value())
+	})
+
+	t.Run("Unmarshal gets data for multiple occurrences field using field tag `index`", func(t *testing.T) {
+		// first, we need to populate fields of composite field
+		// we will do it by packing the field
+		composite := NewMultipleOccurrencesField(multipleOccurrencesVariableLenTestSpec)
+		err := composite.SetData(&[]MultipleOccurrencesTestData{
+			{
+				F1: NewStringValue("AB"),
+				F2: NewStringValue("CD"),
+			},
+			{
+				F1: NewStringValue("EF"),
+				F2: NewStringValue("GH"),
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = composite.Pack()
+		require.NoError(t, err)
+
+		var data []struct {
+			FirstCode  *String `index:"1"`
+			SecondCode *String `index:"2"`
+		}
+		require.NoError(t, composite.Unmarshal(&data))
+
+		require.Equal(t, "AB", data[0].FirstCode.Value())
+		require.Equal(t, "CD", data[0].SecondCode.Value())
+		require.Equal(t, "EF", data[1].FirstCode.Value())
+		require.Equal(t, "GH", data[1].SecondCode.Value())
+	})
+
+	t.Run("Unmarshal ignores struct fields with empty index", func(t *testing.T) {
+		type testObject struct {
+			FirstCode  *String `index:"1"`
+			SecondCode *String `index:"2"`
+			ThirdCode  *String `index:""`
+		}
+
+		composite := NewMultipleOccurrencesField(multipleOccurrencesVariableLenTestSpec)
+		err := composite.SetData(&[]testObject{
+			{
+				FirstCode:  NewStringValue("AB"),
+				SecondCode: NewStringValue("CD"),
+				ThirdCode:  NewStringValue("XD"),
+			},
+			{
+				FirstCode:  NewStringValue("EF"),
+				SecondCode: NewStringValue("GH"),
+				ThirdCode:  NewStringValue("XD"),
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = composite.Pack()
+		require.NoError(t, err)
+
+		var data []testObject
+		require.NoError(t, composite.Unmarshal(&data))
+
+		require.Equal(t, "AB", data[0].FirstCode.Value())
+		require.Equal(t, "CD", data[0].SecondCode.Value())
+		require.Nil(t, data[0].ThirdCode)
+		require.Equal(t, "EF", data[1].FirstCode.Value())
+		require.Equal(t, "GH", data[1].SecondCode.Value())
+		require.Nil(t, data[1].ThirdCode)
+	})
+}
+
+func TestMultipleOccurrences_Packing(t *testing.T) {
+	t.Run("Pack returns an error on mismatch of subfield types", func(t *testing.T) {
+		type TestDataIncorrectType struct {
+			F1 *Numeric
+		}
+		composite := NewMultipleOccurrencesField(multipleOccurrencesFixedLenTestSpec)
+		err := composite.SetData(&[]TestDataIncorrectType{
+			{F1: NewNumericValue(1)},
+		})
+
+		require.Error(t, err)
+		require.EqualError(t, err, "failed to set data from field 1: data does not match required *String type")
+	})
+
+	t.Run("Pack returns error on failure of subfield packing", func(t *testing.T) {
+		composite := NewMultipleOccurrencesField(multipleOccurrencesFixedLenTestSpec)
+		err := composite.SetData(&[]MultipleOccurrencesTestData{
+			{
+				// This subfield will return an error on F1.Pack() as its length
+				// exceeds the max length defined in the spec.
+				F1: NewStringValue("ABCD"),
+				F2: NewStringValue("CD"),
+				F3: NewNumericValue(12),
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = composite.Pack()
+		require.EqualError(t, err, "failed to pack subfield 1: failed to encode length: field length: 4 should be fixed: 2")
+	})
+
+	t.Run("Pack returns error when encoded data length is larger than specified fixed max length", func(t *testing.T) {
+		invalidSpec := &Spec{
+			// Base field length < summation of lengths of subfields
+			// This will throw an error when encoding the field's length.
+			Length: 4,
+			Pref:   prefix.ASCII.Fixed,
+			Tag: &TagSpec{
+				Sort: sort.StringsByInt,
+			},
+			Subfields: map[string]Field{
+				"1": NewString(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+				"2": NewString(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+				"3": NewNumeric(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+			},
+		}
+
+		composite := NewMultipleOccurrencesField(invalidSpec)
+		err := composite.Marshal(&[]MultipleOccurrencesTestData{
+			{
+				F1: NewStringValue("AB"),
+				F2: NewStringValue("CD"),
+				F3: NewNumericValue(12),
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = composite.Pack()
+		require.EqualError(t, err, "failed to encode length: field length: 6 should be fixed: 4")
+	})
+
+	t.Run("Pack returns an error when tag encoding is set to obtain TLV subfields", func(t *testing.T) {
+		invalidSpec := &Spec{
+			Length: 4,
+			Pref:   prefix.ASCII.Fixed,
+			Tag: &TagSpec{
+				Length: 2,
+				Enc:    encoding.ASCII,
+				Sort:   sort.StringsByInt,
+			},
+			Subfields: map[string]Field{
+				"1": NewString(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+				"2": NewString(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+				"3": NewNumeric(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+			},
+		}
+
+		composite := NewMultipleOccurrencesField(invalidSpec)
+
+		_, err := composite.Pack()
+		require.EqualError(t, err, "unsupported packing of TLV subfields")
+	})
+
+	t.Run("Pack correctly serializes data with padded tags to bytes", func(t *testing.T) {
+		composite := NewMultipleOccurrencesField(multipleOccurrencesFixedLenTestSpec)
+		err := composite.SetData(&[]MultipleOccurrencesTestData{
+			{
+				F1: NewStringValue("AB"),
+				F2: NewStringValue("CD"),
+				F3: NewNumericValue(12),
+			},
+			{
+				F1: NewStringValue("CD"),
+				F2: NewStringValue("EF"),
+				F3: NewNumericValue(14),
+			},
+		})
+		require.NoError(t, err)
+
+		packed, err := composite.Pack()
+		require.NoError(t, err)
+
+		require.Equal(t, "ABCD12CDEF14", string(packed))
+	})
+
+	t.Run("Unpack returns an error on mismatch of subfield types", func(t *testing.T) {
+		type TestDataIncorrectType struct {
+			F1 *Numeric
+		}
+		composite := NewMultipleOccurrencesField(multipleOccurrencesFixedLenTestSpec)
+
+		_, err := composite.Unpack([]byte("ABCD12EFGH12"))
+		require.NoError(t, err)
+
+		err = composite.Unmarshal(&[]TestDataIncorrectType{})
+
+		require.Error(t, err)
+		require.EqualError(t, err, "failed to get data from field 1: data does not match required *String type")
+	})
+
+	t.Run("Unpack returns an error on failure of subfield to unpack bytes", func(t *testing.T) {
+		composite := NewMultipleOccurrencesField(multipleOccurrencesFixedLenTestSpec)
+
+		// Last two characters must be an integer type. F3 fails to unpack.
+		read, err := composite.Unpack([]byte("ABCDEF01AB50"))
+		require.Equal(t, 0, read)
+		require.Error(t, err)
+		require.EqualError(t, err, "failed to unpack subfield 3: failed to set bytes: failed to convert into number")
+		require.ErrorIs(t, err, strconv.ErrSyntax)
+	})
+
+	t.Run("Unpack returns an error when not enough data is set", func(t *testing.T) {
+		composite := NewMultipleOccurrencesField(multipleOccurrencesFixedLenTestSpec)
+
+		// Last two characters must be an integer type. F3 fails to unpack.
+		read, err := composite.Unpack([]byte("ABCD10"))
+		require.Equal(t, 0, read)
+		require.Error(t, err)
+		require.EqualError(t, err, "not enough data to unpack, expected: 12, got: 6")
+	})
+
+	t.Run("Unpack returns an error on length of data exceeding max length", func(t *testing.T) {
+		spec := &Spec{
+			Length: 4,
+			Pref:   prefix.ASCII.L,
+			Tag: &TagSpec{
+				Sort: sort.StringsByInt,
+			},
+			Subfields: map[string]Field{
+				"1": NewString(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+				"2": NewString(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+				"3": NewNumeric(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+			},
+		}
+
+		composite := NewMultipleOccurrencesField(spec)
+
+		// Length of denoted by prefix is too long, causing failure to decode length.
+		read, err := composite.Unpack([]byte("7ABCD123"))
+		require.Equal(t, 0, read)
+		require.Error(t, err)
+		require.EqualError(t, err, "failed to decode length: data length: 7 is larger than maximum 4")
+	})
+
+	t.Run("Unpack without error when not all subfields are set", func(t *testing.T) {
+		spec := &Spec{
+			Length: 4,
+			Pref:   prefix.ASCII.L,
+			Tag: &TagSpec{
+				Sort: sort.StringsByInt,
+			},
+			Subfields: map[string]Field{
+				"1": NewString(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+				"2": NewString(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+				"3": NewNumeric(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+			},
+		}
+
+		composite := NewMultipleOccurrencesField(spec)
+
+		// There is data only for first subfield
+		read, err := composite.Unpack([]byte("2AB"))
+		require.Equal(t, 3, read)
+		require.NoError(t, err)
+	})
+
+	t.Run("Unpack returns an error on offset not matching data length", func(t *testing.T) {
+		invalidSpec := &Spec{
+			// Base field length < summation of lengths of subfields
+			// This will throw an error when encoding the field's length.
+			Length: 4,
+			Pref:   prefix.ASCII.Fixed,
+			Tag: &TagSpec{
+				Sort: sort.StringsByInt,
+			},
+			Subfields: map[string]Field{
+				"1": NewString(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+				"2": NewString(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+				"3": NewNumeric(&Spec{
+					Length: 3,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+			},
+		}
+
+		composite := NewMultipleOccurrencesField(invalidSpec)
+
+		// Length of input too long, causing failure to decode length.
+		read, err := composite.Unpack([]byte("ABCD123"))
+		require.Equal(t, 0, read)
+		require.Error(t, err)
+		require.EqualError(t, err, "failed to unpack subfield 3: failed to decode content: not enough data to decode. expected len 3, got 0")
+	})
+
+	t.Run("Unpack returns an error when tag encoding is set to obtain TLV subfields", func(t *testing.T) {
+		invalidSpec := &Spec{
+			Length: 4,
+			Pref:   prefix.ASCII.Fixed,
+			Tag: &TagSpec{
+				Length: 2,
+				Enc:    encoding.ASCII,
+				Sort:   sort.StringsByInt,
+			},
+			Subfields: map[string]Field{
+				"1": NewString(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+				"2": NewString(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+				"3": NewNumeric(&Spec{
+					Length: 3,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+			},
+		}
+
+		composite := NewMultipleOccurrencesField(invalidSpec)
+
+		// Length of input too long, causing failure to decode length.
+		read, err := composite.Unpack([]byte("AB10CD123"))
+		require.Equal(t, 0, read)
+		require.Error(t, err)
+		require.EqualError(t, err, "unsupported unpacking of TLV subfields")
+	})
+
+	t.Run("Unpack correctly deserializes bytes to the data struct", func(t *testing.T) {
+		composite := NewMultipleOccurrencesField(multipleOccurrencesFixedLenTestSpec)
+
+		read, err := composite.Unpack([]byte("ABCD1205GH14"))
+		require.Equal(t, multipleOccurrencesFixedLenTestSpec.Length, read)
+		require.NoError(t, err)
+
+		var data []MultipleOccurrencesTestData
+		require.NoError(t, composite.Unmarshal(&data))
+
+		require.Equal(t, "AB", data[0].F1.Value())
+		require.Equal(t, "CD", data[0].F2.Value())
+		require.Equal(t, 12, data[0].F3.Value())
+		require.Nil(t, data[0].F11)
+		require.Equal(t, "05", data[1].F1.Value())
+		require.Equal(t, "GH", data[1].F2.Value())
+		require.Equal(t, 14, data[1].F3.Value())
+		require.Nil(t, data[1].F11)
+	})
+
+	t.Run("SetBytes correctly deserializes bytes to the data struct", func(t *testing.T) {
+		composite := NewMultipleOccurrencesField(multipleOccurrencesFixedLenTestSpec)
+
+		require.NoError(t, composite.SetBytes([]byte("ABCD12")))
+
+		var data []MultipleOccurrencesTestData
+		require.NoError(t, composite.Unmarshal(&data))
+
+		require.Equal(t, "AB", data[0].F1.Value())
+		require.Equal(t, "CD", data[0].F2.Value())
+		require.Equal(t, 12, data[0].F3.Value())
+		require.Nil(t, data[0].F11)
+	})
+}
+
+func TestMultipleOccurrences_HandlesValidSpecs(t *testing.T) {
+	tests := []struct {
+		desc string
+		spec *Spec
+	}{
+		{
+			desc: "accepts nil Enc value",
+			spec: &Spec{
+				Length: 6,
+				Pref:   prefix.ASCII.Fixed,
+				Tag: &TagSpec{
+					Sort: sort.StringsByInt,
+				},
+				Subfields: map[string]Field{},
+			},
+		},
+		{
+			desc: "accepts nil Pad value",
+			spec: &Spec{
+				Length: 6,
+				Pref:   prefix.ASCII.Fixed,
+				Tag: &TagSpec{
+					Sort: sort.StringsByInt,
+				},
+				Subfields: map[string]Field{},
+			},
+		},
+		{
+			desc: "accepts None Pad value",
+			spec: &Spec{
+				Length: 6,
+				Pref:   prefix.ASCII.Fixed,
+				Pad:    padding.None,
+				Tag: &TagSpec{
+					Sort: sort.StringsByInt,
+				},
+				Subfields: map[string]Field{},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("NewMultipleOccurrencesField() %v", tc.desc), func(t *testing.T) {
+			f := NewMultipleOccurrencesField(tc.spec)
+			require.Equal(t, tc.spec, f.Spec())
+		})
+		t.Run(fmt.Sprintf("MultipleOccurrencesField.SetSpec() %v", tc.desc), func(t *testing.T) {
+			f := &MultipleOccurrences{}
+			f.SetSpec(tc.spec)
+			require.Equal(t, tc.spec, f.Spec())
+		})
+	}
+}
+
+func TestMultipleOccurrences_PanicsOnSpecValidationFailures(t *testing.T) {
+	tests := []struct {
+		desc string
+		err  string
+		spec *Spec
+	}{
+		{
+			desc: "panics on nil Tag.Sort",
+			err:  "Composite spec requires a Tag.Sort function to define a Tag",
+			spec: &Spec{
+				Length:    6,
+				Pref:      prefix.ASCII.Fixed,
+				Subfields: map[string]Field{},
+				Tag:       &TagSpec{},
+			},
+		},
+		{
+			desc: "panics on non-None / non-nil Pad value being defined in spec",
+			err:  "Composite spec only supports nil or None spec padding values",
+			spec: &Spec{
+				Length:    6,
+				Pref:      prefix.ASCII.Fixed,
+				Pad:       padding.Left('0'),
+				Subfields: map[string]Field{},
+				Tag: &TagSpec{
+					Sort: sort.StringsByInt,
+				},
+			},
+		},
+		{
+			desc: "panics on non-nil Enc value being defined in spec",
+			err:  "Composite spec only supports a nil Enc value",
+			spec: &Spec{
+				Length:    6,
+				Enc:       encoding.ASCII,
+				Pref:      prefix.ASCII.Fixed,
+				Subfields: map[string]Field{},
+				Tag: &TagSpec{
+					Sort: sort.StringsByInt,
+				},
+			},
+		},
+		{
+			desc: "panics on nil Enc value being defined in spec if Tag.Length > 0",
+			err:  "Composite spec requires a Tag.Enc to be defined if Tag.Length > 0",
+			spec: &Spec{
+				Length:    6,
+				Pref:      prefix.ASCII.Fixed,
+				Subfields: map[string]Field{},
+				Tag: &TagSpec{
+					Length: 2,
+					Pad:    padding.Left('0'),
+					Sort:   sort.StringsByInt,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("NewMultipleOccurrencesField() %v", tc.desc), func(t *testing.T) {
+			require.PanicsWithError(t, tc.err, func() {
+				NewMultipleOccurrencesField(tc.spec)
+			})
+		})
+		t.Run(fmt.Sprintf("MultipleOccurrencesField.SetSpec() %v", tc.desc), func(t *testing.T) {
+			require.PanicsWithError(t, tc.err, func() {
+				(&MultipleOccurrences{}).SetSpec(tc.spec)
+			})
+		})
+	}
+}
+
+func TestMultipleOccurrences_JSONConversion(t *testing.T) {
+	json := `[{"1":"AB","2":"CD","3":12,"11":{"1":"YZ"}}]`
+
+	t.Run("MarshalJSON typed", func(t *testing.T) {
+		composite := NewMultipleOccurrencesField(multipleOccurrencesVariableLenTestSpec)
+		require.NoError(t, composite.SetData(&[]MultipleOccurrencesTestData{
+			{
+				F1: NewStringValue("AB"),
+				F2: NewStringValue("CD"),
+				F3: NewNumericValue(12),
+				F11: &SubMultipleOccurrencesData{
+					F1: NewStringValue("YZ"),
+				},
+			},
+		}))
+
+		actual, err := composite.MarshalJSON()
+		require.NoError(t, err)
+
+		require.JSONEq(t, json, string(actual))
+	})
+
+	t.Run("MarshalJSON untyped", func(t *testing.T) {
+		composite := NewMultipleOccurrencesField(multipleOccurrencesVariableLenTestSpec)
+		require.NoError(t, composite.SetBytes([]byte("02AB02CD0212060102YZ")))
+
+		actual, err := composite.MarshalJSON()
+		require.NoError(t, err)
+
+		require.JSONEq(t, json, string(actual))
+	})
+
+	t.Run("MarshalJSON multiple objects untyped", func(t *testing.T) {
+		expectedResult := `[{"1":"AB","2":"CD","3":12,"11":{"1":"YZ"}},{"1":"AB","2":"CD","3":12,"11":{"1":"YZ"}}]`
+		composite := NewMultipleOccurrencesField(multipleOccurrencesVariableLenTestSpec)
+		require.NoError(t, composite.SetBytes([]byte("02AB02CD0212060102YZ02AB02CD0212060102YZ")))
+
+		actual, err := composite.MarshalJSON()
+		require.NoError(t, err)
+
+		require.JSONEq(t, expectedResult, string(actual))
+	})
+
+	t.Run("UnmarshalJSON error when invalid body is set", func(t *testing.T) {
+		composite := NewMultipleOccurrencesField(multipleOccurrencesVariableLenTestSpec)
+
+		err := composite.UnmarshalJSON([]byte(`{"1":"AB","2":"CD","3":12,"11":{"1":"YZ"}}`))
+
+		require.EqualError(t, err, "failed to JSON unmarshal bytes to map list")
+	})
+
+	t.Run("UnmarshalJSON error when invalid subfield is set", func(t *testing.T) {
+		composite := NewMultipleOccurrencesField(multipleOccurrencesVariableLenTestSpec)
+
+		err := composite.UnmarshalJSON([]byte(`[{"1":"AB","2":"CD","3":12,"11":"YZ"}]`))
+
+		require.EqualError(t, err, "failed to unmarshal subfield 11")
+	})
+
+	t.Run("UnmarshalJSON typed", func(t *testing.T) {
+		multipleJson := `[{"1":"AB","2":"CD","3":12,"11":{"1":"YZ"}},{"1":"EF","2":"GH","3":15}]`
+		composite := NewMultipleOccurrencesField(multipleOccurrencesVariableLenTestSpec)
+		require.NoError(t, composite.UnmarshalJSON([]byte(multipleJson)))
+
+		var data []MultipleOccurrencesTestData
+		require.NoError(t, composite.Unmarshal(&data))
+
+		require.Equal(t, "AB", data[0].F1.Value())
+		require.Equal(t, "CD", data[0].F2.Value())
+		require.Equal(t, 12, data[0].F3.Value())
+		require.Equal(t, "YZ", data[0].F11.F1.Value())
+		require.Equal(t, "EF", data[1].F1.Value())
+		require.Equal(t, "GH", data[1].F2.Value())
+		require.Equal(t, 15, data[1].F3.Value())
+		require.Nil(t, data[1].F11)
+	})
+
+	t.Run("UnmarshalJSON untyped", func(t *testing.T) {
+		composite := NewMultipleOccurrencesField(multipleOccurrencesVariableLenTestSpec)
+
+		require.NoError(t, composite.UnmarshalJSON([]byte(json)))
+
+		s, err := composite.String()
+		require.NoError(t, err)
+		require.Equal(t, "02AB02CD0212060102YZ", s)
+	})
+}


### PR DESCRIPTION
Added a Composite implementation to hold ISO8583 subfields that can appear multiple times in the same field, calling each of these appearances an occurrence.